### PR TITLE
Update api.go to support self-signed panels

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,7 +27,14 @@ var cookieCache struct {
 }
 
 func createHttpClient() *http.Client {
-	return &http.Client{Timeout: 30 * time.Second}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	return &http.Client{
+		Transport: tr,
+		Timeout:   30 * time.Second,
+	}
 }
 
 func GetAuthToken() (*http.Cookie, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"x-ui-exporter/config"
 	"x-ui-exporter/metrics"
+	"crypto/tls"
 )
 
 // API logic partially was taken from the client3xui module
@@ -28,7 +29,9 @@ var cookieCache struct {
 
 func createHttpClient() *http.Client {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: config.CLIConfig.InsecureSkipVerify,
+		},
 	}
 
 	return &http.Client{

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -14,7 +14,7 @@ panel-password: "your-password"
 
 # Skip SSL certificate verification (NOT recommended for production)
 # Use this only if your panel uses self-signed certificates
-# or when using p
+# or when using a private trusted network
 insecure-skip-verify: false
 
 # General settings

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -12,6 +12,11 @@ panel-username: "your-username"
 # Password for 3X-UI API authentication (required)
 panel-password: "your-password"
 
+# Skip SSL certificate verification (NOT recommended for production)
+# Use this only if your panel uses self-signed certificates
+# or when using p
+insecure-skip-verify: false
+
 # General settings
 # Interval in seconds between updates from the panel (default: 30)
 update-interval: 30

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type CLI struct {
 	BaseURL          string      `name:"panel-base-url" help:"Panel base URL" env:"PANEL_BASE_URL" env:"PANEL_BASE_URL"`
 	ApiUsername      string      `name:"panel-username" help:"Panel username" env:"PANEL_USERNAME" env:"PANEL_USERNAME"`
 	ApiPassword      string      `name:"panel-password" help:"Panel password" env:"PANEL_PASSWORD" env:"PANEL_PASSWORD"`
+	InsecureSkipVerify bool      `name:"insecure-skip-verify" help:"Skip SSL certificate verification (INSECURE)" default:"false" env:"INSECURE_SKIP_VERIFY"`
 	ConfigFile       string      `name:"config-file" help:"Path to a YAML configuration file" env:"CONFIG_FILE"`
 	Version          VersionFlag `name:"version" help:"Print version information and quit"`
 }

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -8,16 +8,17 @@ import (
 // YAMLConfig mirrors the CLI struct but with YAML struct tags.
 // This structure is used for parsing configuration from YAML files.
 type YAMLConfig struct {
-	Port             string `yaml:"metrics-port"`
-	ProtectedMetrics bool   `yaml:"metrics-protected"`
-	MetricsUsername  string `yaml:"metrics-username"`
-	MetricsPassword  string `yaml:"metrics-password"`
-	UpdateInterval   int    `yaml:"update-interval"`
-	TimeZone         string `yaml:"timezone"`
-	BaseURL          string `yaml:"panel-base-url"`
-	ApiUsername      string `yaml:"panel-username"`
-	ApiPassword      string `yaml:"panel-password"`
-	Version          string `yaml:"version,omitempty"`
+	Port               string `yaml:"metrics-port"`
+	ProtectedMetrics   bool   `yaml:"metrics-protected"`
+	MetricsUsername    string `yaml:"metrics-username"`
+	MetricsPassword    string `yaml:"metrics-password"`
+	UpdateInterval     int    `yaml:"update-interval"`
+	TimeZone           string `yaml:"timezone"`
+	BaseURL            string `yaml:"panel-base-url"`
+	ApiUsername        string `yaml:"panel-username"`
+	ApiPassword        string `yaml:"panel-password"`
+	Version            string `yaml:"version,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecure-skip-verify"`
 }
 
 // LoadYAMLConfig loads and parses the YAML configuration file at the given path.
@@ -49,6 +50,7 @@ func (y *YAMLConfig) ToCLI() CLI {
 		BaseURL:          y.BaseURL,
 		ApiUsername:      y.ApiUsername,
 		ApiPassword:      y.ApiPassword,
+		InsecureSkipVerify: y.InsecureSkipVerify,
 		// ConfigFile is not included as it's a CLI-specific field
 		// Version field is ignored as it's handled differently in CLI
 	}


### PR DESCRIPTION
Support self-signed certs for panels on private IPs.

Previously, the HTTP client rejected panels using self-signed TLS certificates, which caused issues when panels were bound to private IPs (e.g. 192.168.x.x). This change modifies the HTTP client to skip TLS certificate verification, allowing connections to those panels. HTTP behavior is unchanged.