### PR TITLE
feat(config): add support for custom metrics IP binding via --metrics-ip

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -20,6 +20,9 @@ update-interval: 30
 timezone: "UTC"
 
 # Metrics server configuration
+# Port for the metrics server (default: 0.0.0.0)
+metrics-ip: "0.0.0.0"
+
 # Port for the metrics server (default: 9090)
 metrics-port: "9090"
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ var CLIConfig CLI
 type VersionFlag string
 
 type CLI struct {
+	Ip               string      `name:"metrics-ip" help:"Ip to listen on" default:"0.0.0.0" env:"METRICS_IP"`
 	Port             string      `name:"metrics-port" help:"Port to listen on" default:"9090" env:"METRICS_PORT"`
 	ProtectedMetrics bool        `name:"metrics-protected" help:"Whether metrics are protected by basic auth" default:"false" env:"METRICS_PROTECTED"`
 	MetricsUsername  string      `name:"metrics-username" help:"Username for metrics if protected by basic auth" default:"metricsUser" env:"METRICS_USERNAME"`

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -8,6 +8,7 @@ import (
 // YAMLConfig mirrors the CLI struct but with YAML struct tags.
 // This structure is used for parsing configuration from YAML files.
 type YAMLConfig struct {
+	Ip               string `yaml:"metrics-ip"`
 	Port             string `yaml:"metrics-port"`
 	ProtectedMetrics bool   `yaml:"metrics-protected"`
 	MetricsUsername  string `yaml:"metrics-username"`
@@ -40,6 +41,7 @@ func LoadYAMLConfig(path string) (*YAMLConfig, error) {
 // This is used to merge YAML configuration with command-line flags.
 func (y *YAMLConfig) ToCLI() CLI {
 	return CLI{
+		Ip:				  y.Ip,
 		Port:             y.Port,
 		ProtectedMetrics: y.ProtectedMetrics,
 		MetricsUsername:  y.MetricsUsername,

--- a/main.go
+++ b/main.go
@@ -87,6 +87,6 @@ func main() {
 
 	http.Handle("/metrics", BasicAuthMiddleware(config.CLIConfig.MetricsUsername,
 		config.CLIConfig.MetricsPassword)(promhttp.Handler()))
-	log.Printf("Starting server on :%s", config.CLIConfig.Port)
-	log.Fatal(http.ListenAndServe(":"+config.CLIConfig.Port, nil))
+	log.Printf("Starting server on %s:%s", config.CLIConfig.Ip, config.CLIConfig.Port)
+	log.Fatal(http.ListenAndServe(config.CLIConfig.Ip":"+config.CLIConfig.Port, nil))
 }


### PR DESCRIPTION
### Summary

This PR adds support for configuring the IP address the metrics server binds to using the new `--metrics-ip` CLI flag or `metrics-ip` option in the YAML config.

### Changes

- Added `Ip` field to `CLI` and `YAMLConfig` structs
- Applied default `0.0.0.0` (bind all interfaces)
- Updated `main.go` to bind metrics server using `IP:Port`
- Updated example YAML config with the new option

### Why

This allows users to explicitly bind the exporter to `localhost`, a specific interface, or keep the default behavior of `0.0.0.0` for external access.
